### PR TITLE
Use newer version of cbjavaloader

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,7 +5,7 @@
     "private": false,
     "dependencies": {
         "coldbox": "^4.3.0+188",
-        "cbjavaloader": "^1.4.0",
+        "cbjavaloader": "^2",
         "cbswagger": "^1.2.1",
         "wikitext": "^1.2.0"
     },


### PR DESCRIPTION
Trying to removing dependencies on different module version if not needed. Would you please accept this and publish a new version of relax?

Also, consider removing this dependency. Unless I'm missing something, I couldn't see where cbjavaloader was referenced.